### PR TITLE
Fix server lock handling

### DIFF
--- a/checker.py
+++ b/checker.py
@@ -25,9 +25,20 @@ async def handle_server():
         updated_labels = labels.copy()
         modified = False
 
-        if labels.get("locked") != "true":
-            updated_labels["locked"] = "true"
-            modified = True
+        # Check if delete and rebuild protections are enabled
+        protection = server.get("protection", {})
+        delete_protection = protection.get("delete", False)
+        rebuild_protection = protection.get("rebuild", False)
+
+        if not delete_protection or not rebuild_protection:
+            payload = {"delete": True, "rebuild": True}
+            print(f"Enabling protection for server {server_id}: {payload}")
+            protection_resp = requests.post(
+                f"{base_url}/servers/{server_id}/actions/change_protection",
+                headers=HEADERS,
+                json=payload,
+            )
+            protection_resp.raise_for_status()
 
         if labels.get("Autobackup") != "true":
             updated_labels["Autobackup"] = "true"


### PR DESCRIPTION
## Summary
- check Hetzner server protection instead of using a label
- if delete or rebuild protection is disabled enable it via the `change_protection` action
- keep Autobackup label functionality

## Testing
- `python3 -m py_compile checker.py`


------
https://chatgpt.com/codex/tasks/task_b_68763602388083229a4e733dc46f372e